### PR TITLE
Optionally build example.c with "make example"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -50,3 +50,14 @@ dist_noinst_DATA = \
 	AUTHORS COPYING README \
 	example.c \
 	testinput.c
+
+if CAN_COMPILE_EXAMPLE
+EXTRA_PROGRAMS = example
+example_SOURCES = example.c
+example_LDADD = libblkmaker-$(LIBBLKMAKER_API_VERSION).la libblkmaker_jansson-$(LIBBLKMAKER_API_VERSION).la $(LIBGCRYPT_LIBS)
+example_CFLAGS = $(LIBGCRYPT_CFLAGS)
+else
+example:
+    @echo "libgcrypt is required to build the example, but was not found"
+.PHONY: example
+endif

--- a/README
+++ b/README
@@ -5,7 +5,8 @@ Example dependencies:
 	Jansson 2.1 (to read JSON from stdin)
 	libgcrypt (for SHA256)
 
-For usage, check out example.c
+For usage, check out example.c. Run "make example" to build it.
+
 Note that you must assign blkmk_sha256_impl to a function pointer:
 	bool mysha256(void *hash_out, const void *data, size_t datasz)
 hash_out must be able to overlap with data!

--- a/configure.ac
+++ b/configure.ac
@@ -51,4 +51,18 @@ PKG_CHECK_MODULES([libbase58],[libbase58])
 
 AC_CHECK_LIB([ws2_32], [strchr])
 
+#libgcrypt necessary to build example.c with "make example"
+#check for libgcrypt:
+m4_ifdef([AM_PATH_LIBGCRYPT], [
+	AM_PATH_LIBGCRYPT([],
+		[
+			[can_compile_example=yes]
+		],[
+			[compile_example=no]
+		])
+],[
+        m4_warn([syntax], [AM_PATH_LIBGCRYPT missing; CLI tool will not be available])
+])
+AM_CONDITIONAL([CAN_COMPILE_EXAMPLE], [test x$can_compile_example = xyes])
+
 AC_OUTPUT


### PR DESCRIPTION
`Makefile.am` modified to create `Makefile` that automatically compiles `example.c` locally but does not install it