### PR TITLE
Handle coinbasevalue=0 correctly

### DIFF
--- a/blkmaker.c
+++ b/blkmaker.c
@@ -178,7 +178,7 @@ uint64_t blkmk_init_generation3(blktemplate_t * const tmpl, const void * const s
 		return 0;
 	}
 	
-	if (!tmpl->cbvalue) {
+	if (!tmpl->has_cbvalue) {
 		// TODO: Figure it out from the existing cbtxn
 		return 0;
 	}
@@ -798,7 +798,9 @@ bool blkmk_get_mdata(blktemplate_t * const tmpl, void * const buf, const size_t 
 		free(*out_cbtxn);
 		return false;
 	}
-	memcpy(*out_branches, tmpl->_mrklbranch, branches_bytesz);
+	if (branches_bytesz) {
+		memcpy(*out_branches, tmpl->_mrklbranch, branches_bytesz);
+	}
 	
 	return true;
 }

--- a/blkmaker.c
+++ b/blkmaker.c
@@ -56,19 +56,18 @@ bool _blkmk_dblsha256(void *hash, const void *data, size_t datasz) {
 #define dblsha256 _blkmk_dblsha256
 
 uint64_t blkmk_init_generation3(blktemplate_t * const tmpl, const void * const script, const size_t scriptsz, bool * const inout_newcb) {
-	if (tmpl->cbtxn && !(*inout_newcb && (tmpl->mutations & BMM_GENERATE)))
+	const bool replace_existing = *inout_newcb;
+	*inout_newcb = false;
+	
+	if (tmpl->cbtxn && !(replace_existing && (tmpl->mutations & BMM_GENERATE)))
 	{
-		*inout_newcb = false;
 		return 0;
 	}
 	
 	if (!tmpl->cbvalue) {
 		// TODO: Figure it out from the existing cbtxn
-		*inout_newcb = false;
 		return 0;
 	}
-	
-	*inout_newcb = true;
 	
 	if (scriptsz >= 0xfd)
 		return 0;
@@ -133,6 +132,7 @@ uint64_t blkmk_init_generation3(blktemplate_t * const tmpl, const void * const s
 	
 	tmpl->mutations |= BMM_CBAPPEND | BMM_CBSET | BMM_GENERATE;
 	
+	*inout_newcb = true;
 	return tmpl->cbvalue;
 }
 

--- a/blkmaker_jansson.c
+++ b/blkmaker_jansson.c
@@ -416,7 +416,14 @@ const char *blktmpl_add_jansson(blktemplate_t *tmpl, const json_t *json, time_t 
 			return "Unrecognized block version, and not allowed to reduce or force it";
 	}
 	
-	GETNUM_O2(cbvalue, coinbasevalue, uint64_t);
+	if ((v = json_object_get(json, "coinbasevalue")) && json_is_number(v)) {
+		const double tmpd = json_number_value(v);
+		const uint64_t tmp = tmpd;
+		if (tmpd == tmp) {
+			tmpl->has_cbvalue = true;
+			tmpl->cbvalue = tmp;
+		}
+	}
 	
 	GETSTR(workid, workid);
 	
@@ -464,7 +471,7 @@ const char *blktmpl_add_jansson(blktemplate_t *tmpl, const json_t *json, time_t 
 		tmpl->cbtxn = calloc(1, sizeof(*tmpl->cbtxn));
 		if ((s = parse_txn(tmpl->cbtxn, v, 0)))
 			return s;
-	} else if (!tmpl->cbvalue) {
+	} else if (!tmpl->has_cbvalue) {
 		return "Missing either coinbasetxn or coinbasevalue";
 	}
 	

--- a/blktemplate.h
+++ b/blktemplate.h
@@ -158,6 +158,8 @@ typedef struct {
 	libblkmaker_hash_t *_witnessmrklroot;
 	int64_t weightlimit;
 	int64_t txns_weight;
+	
+	bool has_cbvalue;
 } blktemplate_t;
 
 extern void blktxn_init(struct blktxn_t *);

--- a/test.c
+++ b/test.c
@@ -219,6 +219,7 @@ static void blktmpl_jansson_simple() {
 		assert(tmpl->prevblk[i] == 0x77777777);
 	}
 	assert(!tmpl->prevblk[7]);
+	assert(tmpl->has_cbvalue);
 	assert(tmpl->cbvalue == 512);
 	
 	// Check clear values
@@ -246,6 +247,13 @@ static void blktmpl_jansson_simple() {
 	assert(tmpl->mintime <= tmpl->curtime - 60);
 	assert(tmpl->mintimeoff <= -60);
 	
+	blktmpl_free(tmpl);
+	tmpl = blktmpl_create();
+	
+	assert(!blktmpl_add_jansson_str(tmpl, "{\"version\":2,\"height\":3,\"bits\":\"1d00ffff\",\"curtime\":777,\"previousblockhash\":\"0000000077777777777777777777777777777777777777777777777777777777\",\"coinbasevalue\":0}", simple_time_rcvd));
+	assert(tmpl->has_cbvalue);
+	assert(tmpl->cbvalue == 0);
+
 	blktmpl_free(tmpl);
 	tmpl = blktmpl_create();
 	
@@ -287,6 +295,7 @@ static void blktmpl_jansson_bip22_required() {
 		assert(tmpl->prevblk[i] == 0xa7777777);
 	}
 	assert(!tmpl->prevblk[7]);
+	assert(tmpl->has_cbvalue);
 	assert(tmpl->cbvalue == 640);
 	assert(tmpl->sigoplimit == 100);
 	assert(tmpl->sizelimit == 1000);
@@ -475,6 +484,7 @@ static void test_blktmpl_jansson_floaty() {
 		assert(tmpl->prevblk[i] == 0x77777777);
 	}
 	assert(!tmpl->prevblk[7]);
+	assert(tmpl->has_cbvalue);
 	assert(tmpl->cbvalue == 512);
 	
 	assert(tmpl->txncount == 2);
@@ -534,6 +544,7 @@ static void test_blktmpl_jansson_floaty() {
 		assert(tmpl->prevblk[i] == 0x77777777);
 	}
 	assert(!tmpl->prevblk[7]);
+	assert(!tmpl->has_cbvalue);
 	assert(!tmpl->cbvalue);
 	
 	assert(tmpl->expires == 33);
@@ -1122,6 +1133,7 @@ static void test_blkmk_init_generation() {
 	assert(!blkmk_init_generation(tmpl, NULL, 0));
 	tmpl->height = 4;
 	assert(blkmk_init_generation(tmpl, NULL, 0) == 640);
+	tmpl->has_cbvalue = false;
 	tmpl->cbvalue = 0;
 	newcb = true;
 	// Unknown cbvalue needs to either fail, or figure it out from an existing cbtxn (which we don't support yet)


### PR DESCRIPTION
Library users who access `blktemplate_t.cbvalue` directly will need to update to get `.has_cbvalue` instead, but this should take care of fixing #12 for the library's own usage at least.